### PR TITLE
feature: benchmark class for HHI

### DIFF
--- a/src/config/hhi.yaml
+++ b/src/config/hhi.yaml
@@ -1,0 +1,23 @@
+type: "hhi"
+description: >
+  HHI (Herfindahl-Hirschman Index) Benchmark for Supply Risk Assessment
+version: "0.1.0"
+
+# Weights for different HHI components
+production_weight: 0.25
+reserve_weight: 0.75
+
+# Scaling configuration
+scale_to_0_10: true
+
+# Risk assessment thresholds (for scaled values 0-10)
+# Low risk: HHI <= 2.0
+# Moderate risk: 2.0 < HHI <= 5.0  
+# High risk: HHI > 5.0
+
+# Additional metadata
+metadata:
+  reference: >
+    Herfindahl-Hirschman Index for supply risk assessment
+  use_case: >
+    Evaluating element supply concentration risk in materials

--- a/src/config/hhi.yaml
+++ b/src/config/hhi.yaml
@@ -4,6 +4,13 @@ description: >
 version: "0.1.0"
 
 # Weights for different HHI components
+# Default weights prioritize long-term supply security over short-term 
+# market dynamics. Reserve concentration (0.75) reflects fundamental 
+# geological availability and is harder to change, while production 
+# concentration (0.25) can be adjusted through investment and trade 
+# diversification. This weighting is optimal for materials discovery 
+# where ong-term elemment availability is more critical than current 
+# market conditions.
 production_weight: 0.25
 reserve_weight: 0.75
 

--- a/src/lematerial_forgebench/benchmarks/__init__.py
+++ b/src/lematerial_forgebench/benchmarks/__init__.py
@@ -7,6 +7,7 @@ Each benchmark represents a different aspect of quality assessment.
 
 from .base import BaseBenchmark, BenchmarkConfig, BenchmarkResult
 from .distribution_benchmark import DistributionBenchmark
+from .hhi_benchmark import HHIBenchmark
 from .novelty_benchmark import NoveltyBenchmark
 from .stability_benchmark import StabilityBenchmark
 from .uniqueness_benchmark import UniquenessBenchmark
@@ -19,7 +20,8 @@ __all__ = [
     "BenchmarkResult",
     # Benchmark implementations
     "DistributionBenchmark",
-    "NoveltyBenchmark",
+    "HHIBenchmark",
+    "NoveltyBenchmark", 
     "StabilityBenchmark",
     "UniquenessBenchmark",
     "ValidityBenchmark",

--- a/src/lematerial_forgebench/benchmarks/hhi_benchmark.py
+++ b/src/lematerial_forgebench/benchmarks/hhi_benchmark.py
@@ -8,8 +8,6 @@ reserves.
 import math
 from typing import Any, Dict
 
-import numpy as np
-
 from lematerial_forgebench.benchmarks.base import BaseBenchmark
 from lematerial_forgebench.evaluator import EvaluatorConfig
 from lematerial_forgebench.metrics.hhi_metrics import (

--- a/src/lematerial_forgebench/benchmarks/hhi_benchmark.py
+++ b/src/lematerial_forgebench/benchmarks/hhi_benchmark.py
@@ -25,6 +25,13 @@ class HHIBenchmark(BaseBenchmark):
         self,
         production_weight: float = 0.25,
         reserve_weight: float = 0.75,
+        # Default weights prioritize long-term supply security over short-term 
+        # market dynamics. Reserve concentration (0.75) reflects fundamental 
+        # geological availability and is harder to change, while production 
+        # concentration (0.25) can be adjusted through investment and trade 
+        # diversification. This weighting is optimal for materials discovery 
+        # where ong-term element availability is more critical than current 
+        # market conditions.
         scale_to_0_10: bool = True,
         name: str = "HHIBenchmark",
         description: str | None = None,
@@ -200,7 +207,7 @@ class HHIBenchmark(BaseBenchmark):
             )
 
         # Compute weighted average of production and reserve HHI
-        # Handle None values properly (FIXED: Check for None first, then NaN)
+        # Handle None values properly
         def is_none_or_nan(value):
             """Check if value is None or NaN."""
             if value is None:

--- a/src/lematerial_forgebench/benchmarks/hhi_benchmark.py
+++ b/src/lematerial_forgebench/benchmarks/hhi_benchmark.py
@@ -1,0 +1,245 @@
+"""HHI (Herfindahl-Hirschman Index) benchmark for material structures.
+
+This module implements a benchmark that evaluates the supply risk concentration
+of generated material structures using HHI metrics for both production and 
+reserves.
+"""
+
+import math
+from typing import Any, Dict
+
+import numpy as np
+
+from lematerial_forgebench.benchmarks.base import BaseBenchmark
+from lematerial_forgebench.evaluator import EvaluatorConfig
+from lematerial_forgebench.metrics.hhi_metrics import (
+    HHIProductionMetric,
+    HHIReserveMetric,
+)
+from lematerial_forgebench.utils.distribution_utils import safe_float
+
+
+class HHIBenchmark(BaseBenchmark):
+    """Benchmark for evaluating the supply risk concentration of generated 
+    material structures."""
+
+    def __init__(
+        self,
+        production_weight: float = 0.25,
+        reserve_weight: float = 0.75,
+        scale_to_0_10: bool = True,
+        name: str = "HHIBenchmark",
+        description: str | None = None,
+        metadata: Dict[str, Any] | None = None,
+    ):
+        """Initialize the HHI benchmark.
+
+        Parameters
+        ----------
+        production_weight : float, default=0.25
+            Weight for production-based HHI metric.
+        reserve_weight : float, default=0.75
+            Weight for reserve-based HHI metric.
+        scale_to_0_10 : bool, default=True
+            Whether to scale HHI values to 0-10 range (True) or keep 0-10000 
+            range (False).
+        name : str
+            Name of the benchmark.
+        description : str, optional
+            Description of the benchmark.
+        metadata : dict, optional
+            Additional metadata for the benchmark.
+        """
+        if description is None:
+            description = (
+                "Evaluates the supply risk concentration of crystal structures "
+                "using Herfindahl-Hirschman Index (HHI) for both production "
+                "and reserves"
+            )
+
+        # Normalize weights
+        total_weight = production_weight + reserve_weight
+        if total_weight > 0:
+            production_weight = production_weight / total_weight
+            reserve_weight = reserve_weight / total_weight
+        else:
+            production_weight = 0.25
+            reserve_weight = 0.75
+
+        # Initialize the HHI metrics
+        production_metric = HHIProductionMetric(scale_to_0_10=scale_to_0_10)
+        reserve_metric = HHIReserveMetric(scale_to_0_10=scale_to_0_10)
+
+        # Set up evaluator configs
+        evaluator_configs = {
+            "hhi_production": EvaluatorConfig(
+                name="hhi_production",
+                description=(
+                    "Evaluates supply risk based on production concentration"
+                ),
+                metrics={"hhi_production": production_metric},
+                weights={"hhi_production": 1.0},
+                aggregation_method="weighted_mean",
+            ),
+            "hhi_reserve": EvaluatorConfig(
+                name="hhi_reserve",
+                description=(
+                    "Evaluates supply risk based on reserve concentration"
+                ),
+                metrics={"hhi_reserve": reserve_metric},
+                weights={"hhi_reserve": 1.0},
+                aggregation_method="weighted_mean",
+            ),
+        }
+
+        # Initialize metadata
+        if metadata is None:
+            metadata = {}
+
+        metadata.update(
+            {
+                "version": "0.1.0",
+                "category": "supply_risk",
+                "scale_to_0_10": scale_to_0_10,
+                "production_weight": production_weight,
+                "reserve_weight": reserve_weight,
+            }
+        )
+
+        # Initialize base benchmark
+        super().__init__(
+            name=name,
+            description=description,
+            evaluator_configs=evaluator_configs,
+            metadata=metadata,
+        )
+
+        # Store weights for aggregation
+        self.production_weight = production_weight
+        self.reserve_weight = reserve_weight
+
+    def aggregate_evaluator_results(
+        self, evaluator_results: dict[str, dict[str, Any]]
+    ) -> dict[str, float]:
+        """Aggregate results from HHI evaluators into final scores.
+
+        Parameters
+        ----------
+        evaluator_results : dict[str, dict[str, Any]]
+            Results from each evaluator containing combined_value and 
+            metric_results in the format created by BaseBenchmark.evaluate()
+
+        Returns
+        -------
+        dict[str, float]
+            Final aggregated scores including individual and combined HHI 
+            metrics
+        """
+        scores = {}
+
+        # Extract production HHI results
+        production_result = evaluator_results.get("hhi_production", {})
+        production_combined = safe_float(
+            production_result.get("combined_value")
+        )
+
+        # Get detailed metrics from the metric_results if available
+        production_metrics = {}
+        if "metric_results" in production_result:
+            hhi_prod_result = production_result["metric_results"].get(
+                "hhi_production"
+            )
+            if hhi_prod_result:
+                if hasattr(hhi_prod_result, "metrics"):
+                    production_metrics = hhi_prod_result.metrics
+                elif (
+                    isinstance(hhi_prod_result, dict)
+                    and "metrics" in hhi_prod_result
+                ):
+                    production_metrics = hhi_prod_result["metrics"]
+
+        # Extract reserve HHI results
+        reserve_result = evaluator_results.get("hhi_reserve", {})
+        reserve_combined = safe_float(reserve_result.get("combined_value"))
+
+        # Get detailed metrics from the metric_results if available
+        reserve_metrics = {}
+        if "metric_results" in reserve_result:
+            hhi_res_result = reserve_result["metric_results"].get(
+                "hhi_reserve"
+            )
+            if hhi_res_result:
+                if hasattr(hhi_res_result, "metrics"):
+                    reserve_metrics = hhi_res_result.metrics
+                elif (
+                    isinstance(hhi_res_result, dict)
+                    and "metrics" in hhi_res_result
+                ):
+                    reserve_metrics = hhi_res_result["metrics"]
+
+        # Individual HHI scores
+        scores["hhi_production_mean"] = production_combined
+        scores["hhi_reserve_mean"] = reserve_combined
+
+        # Add detailed production metrics if available
+        if production_metrics:
+            scores.update(
+                {
+                    f"hhi_production_{k}": v
+                    for k, v in production_metrics.items()
+                    if k != "hhiproduction_mean"  # Avoid duplication
+                }
+            )
+
+        # Add detailed reserve metrics if available
+        if reserve_metrics:
+            scores.update(
+                {
+                    f"hhi_reserve_{k}": v
+                    for k, v in reserve_metrics.items()
+                    if k != "hhireserve_mean"  # Avoid duplication
+                }
+            )
+
+        # Compute weighted average of production and reserve HHI
+        # Handle None values properly (FIXED: Check for None first, then NaN)
+        def is_none_or_nan(value):
+            """Check if value is None or NaN."""
+            if value is None:
+                return True
+            if isinstance(value, float) and math.isnan(value):
+                return True
+            return False
+
+        production_invalid = is_none_or_nan(production_combined)
+        reserve_invalid = is_none_or_nan(reserve_combined)
+
+        if not (production_invalid and reserve_invalid):
+            if production_invalid:
+                scores["hhi_combined_mean"] = reserve_combined
+            elif reserve_invalid:
+                scores["hhi_combined_mean"] = production_combined
+            else:
+                scores["hhi_combined_mean"] = (
+                    self.production_weight * production_combined
+                    + self.reserve_weight * reserve_combined
+                )
+        else:
+            scores["hhi_combined_mean"] = None
+
+        # Risk assessment categories (for scaled values)
+        if self.config.metadata.get("scale_to_0_10", True):
+            # Add risk category counts for combined HHI
+            combined_hhi = scores["hhi_combined_mean"]
+            if not is_none_or_nan(combined_hhi):
+                scores["hhi_low_risk"] = 1.0 if combined_hhi <= 2.0 else 0.0
+                scores["hhi_moderate_risk"] = (
+                    1.0 if 2.0 < combined_hhi <= 5.0 else 0.0
+                )
+                scores["hhi_high_risk"] = 1.0 if combined_hhi > 5.0 else 0.0
+            else:
+                scores["hhi_low_risk"] = None
+                scores["hhi_moderate_risk"] = None
+                scores["hhi_high_risk"] = None
+
+        return scores

--- a/temp.cif
+++ b/temp.cif
@@ -1,16 +1,16 @@
 # generated using pymatgen
 data_Si
 _symmetry_space_group_name_H-M   'P 1'
-_cell_length_a   0.52100064
-_cell_length_b   0.52100078
-_cell_length_c   0.52100064
+_cell_length_a   3.84019793
+_cell_length_b   3.84019899
+_cell_length_c   3.84019793
 _cell_angle_alpha   119.99999086
 _cell_angle_beta   90.00000000
 _cell_angle_gamma   60.00000914
 _symmetry_Int_Tables_number   1
 _chemical_formula_structural   Si
 _chemical_formula_sum   Si2
-_cell_volume   0.10000000
+_cell_volume   40.04479464
 _cell_formula_units_Z   2
 loop_
  _symmetry_equiv_pos_site_id
@@ -25,4 +25,4 @@ loop_
  _atom_site_fract_z
  _atom_site_occupancy
   Si  Si0  1  0.00000000  0.00000000  0.00000000  1
-  Si  Si1  1  0.75000000  0.50000000  0.75000000  1
+  Si  Si1  1  0.08327723  0.05551816  0.08327723  1

--- a/tests/benchmarks/test_hhi_benchmark.py
+++ b/tests/benchmarks/test_hhi_benchmark.py
@@ -1,0 +1,104 @@
+"""Fixed tests for HHI benchmark - addressing the three failing test cases."""
+
+from pymatgen.util.testing import PymatgenTest
+
+from lematerial_forgebench.benchmarks.hhi_benchmark import HHIBenchmark
+
+
+def create_test_structures():
+    """Create test structures for HHI evaluation - fixed to use available structures."""
+    test = PymatgenTest()
+    structures = [
+        test.get_structure("Si"),
+        test.get_structure("LiFePO4"),
+        test.get_structure("CsCl"),  
+    ]
+    return structures
+
+
+class TestHHIBenchmark:
+    """Test suite for HHIBenchmark class."""
+
+    def test_evaluate_with_real_structures(self):
+        """Test benchmark evaluation on real structures."""
+        benchmark = HHIBenchmark()
+        structures = create_test_structures()
+
+        # Run benchmark
+        result = benchmark.evaluate(structures)
+
+        # Check result format
+        assert len(result.evaluator_results) == 2
+        assert "hhi_production" in result.evaluator_results
+        assert "hhi_reserve" in result.evaluator_results
+        
+        # Check final scores exist
+        assert "hhi_production_mean" in result.final_scores
+        assert "hhi_reserve_mean" in result.final_scores
+        assert "hhi_combined_mean" in result.final_scores
+
+        # Check score types (should be float or NaN)
+        for score_name in [
+            "hhi_production_mean",
+            "hhi_reserve_mean", 
+            "hhi_combined_mean",
+        ]:
+            score_value = result.final_scores[score_name]
+            assert isinstance(score_value, (int, float))
+
+    def test_empty_structures(self):
+        """Test behavior with empty structure list."""
+        benchmark = HHIBenchmark()
+
+        # Test behavior with no structures - should not raise error
+        result = benchmark.evaluate([])
+
+        assert result.final_scores["hhi_production_mean"] is None
+        assert result.final_scores["hhi_reserve_mean"] is None
+        assert result.final_scores["hhi_combined_mean"] is None
+
+    def test_missing_evaluator_results(self):
+        """Test handling of missing evaluator results."""
+        benchmark = HHIBenchmark()
+
+        # Test with missing production results
+        partial_results = {
+            "hhi_reserve": {"combined_value": 3.0},
+        }
+        scores = benchmark.aggregate_evaluator_results(partial_results)
+        assert scores["hhi_production_mean"] is None
+        assert scores["hhi_reserve_mean"] == 3.0
+        assert scores["hhi_combined_mean"] == 3.0  # Should use available value
+
+        # Test with missing reserve results
+        partial_results = {
+            "hhi_production": {"combined_value": 4.0},
+        }
+        scores = benchmark.aggregate_evaluator_results(partial_results)
+        
+        assert scores["hhi_production_mean"] == 4.0
+        assert scores["hhi_reserve_mean"] is None
+        assert scores["hhi_combined_mean"] == 4.0  # Should use available value
+
+    # Rest of the tests remain the same as they were working correctly
+    def test_initialization_default(self):
+        """Test initialization with default parameters."""
+        benchmark = HHIBenchmark()
+
+        # Check name and properties
+        assert benchmark.config.name == "HHIBenchmark"
+        assert "version" in benchmark.config.metadata
+        assert benchmark.config.metadata["category"] == "supply_risk"
+        assert benchmark.config.metadata["scale_to_0_10"] is True
+
+        # Check correct evaluators
+        assert len(benchmark.evaluators) == 2
+        assert "hhi_production" in benchmark.evaluators
+        assert "hhi_reserve" in benchmark.evaluators
+
+        # Check weights are normalized
+        assert (
+            abs(
+                benchmark.production_weight + benchmark.reserve_weight - 1.0
+            ) < 1e-6
+        )


### PR DESCRIPTION
addresses HHI part of #43 
## Add HHI (Herfindahl-Hirschman Index) Benchmark for Supply Risk Assessment

### Overview

This PR introduces a new **HHI (Herfindahl-Hirschman Index) Benchmark** to the LeMaterial ForgeBench framework. The HHI benchmark evaluates the supply risk concentration of generated material structures, using production and reserve data for constituent elements. This is a key metric for assessing the supply chain risk and criticality of materials in computational materials discovery.

---

### Key Changes

#### 1. **New Benchmark Implementation**
- **`HHIBenchmark` class** (`src/lematerial_forgebench/benchmarks/hhi_benchmark.py`):
  - Computes HHI scores for both production and reserves.
  - Supports configurable weights for production and reserve components.
  - Optionally scales HHI scores to a 0–10 range for easier risk interpretation.
  - Aggregates results and provides risk categorization (low, moderate, high).

#### 2. **Configuration**
- **`src/config/hhi.yaml`**: Example config file for the HHI benchmark, including weights, scaling, and metadata.

#### 3. **CLI Integration**
- **`src/lematerial_forgebench/cli.py`**:
  - Adds support for running the HHI benchmark via the CLI.
  - Auto-generates a default HHI config if not present.

#### 4. **Benchmark Registration**
- **`src/lematerial_forgebench/benchmarks/__init__.py`**: Registers `HHIBenchmark` for import and CLI use.

#### 5. **Testing**
- **`tests/benchmarks/test_hhi_benchmark.py`**:
  - Adds comprehensive tests for the HHI benchmark, including:
    - Evaluation on real structures.
    - Handling of empty and partial results.
    - Initialization and configuration checks.

---

### Motivation

- **Supply risk** is a critical factor in materials design, especially for high-throughput screening and discovery.
- The HHI is a widely used metric in economics and materials science for quantifying market concentration and supply risk.
- Integrating HHI into GenBench enables users to assess not just the physical or chemical properties of materials, but also their supply chain robustness.

---

### Usage

- Configure and run the HHI benchmark via the CLI:
  ```bash
  python -m lematerial_forgebench.cli --input <structures> --config hhi.yaml --output <results>
  ```
- Adjust weights and scaling in `hhi.yaml` as needed for your use case.

---

**Closes:** #43 HHI Part